### PR TITLE
tests: Force lf line endings for fixtures

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/res/*.txt text eol=lf


### PR DESCRIPTION
The tests actually test both `\n` and `\r\n` style lines, which means on windows we want the fixtures to actually have `\n` line-endings.