### PR TITLE
fix: Correctly parse inlined methods

### DIFF
--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -213,3 +213,54 @@ fn test_iter_access() {
         vec!["android.content.Context", "android.util.AttributeSet"]
     );
 }
+
+#[test]
+fn test_inlined_methods() {
+    // https://github.com/getsentry/rust-proguard/issues/5#issue-410310382
+    let ex = br#"random -> alias:
+    7:8:void method3(long):78:79 -> main
+    7:8:void method2(int):87 -> main
+    7:8:void method1(java.lang.String):95 -> main
+    7:8:void main(java.lang.String[]):101 -> main"#;
+
+    let mapping = MappingView::from_slice(ex).unwrap();
+    let cls = mapping.find_class("alias").unwrap();
+    assert_eq!(cls.members().filter(|m| m.alias() == "main").count(), 4);
+
+    // https://github.com/getsentry/rust-proguard/issues/6#issuecomment-605610326
+    let r8 = br#"com.exmaple.app.MainActivity -> com.exmaple.app.MainActivity:
+    com.example1.domain.MyBean myBean -> p
+    1:1:void <init>():11:11 -> <init>
+    1:1:void buttonClicked(android.view.View):29:29 -> buttonClicked
+    2:2:void com.example1.domain.MyBean.doWork():16:16 -> buttonClicked
+    2:2:void buttonClicked(android.view.View):29 -> buttonClicked
+    1:1:void onCreate(android.os.Bundle):17:17 -> onCreate
+    2:5:void onCreate(android.os.Bundle):22:25 -> onCreate"#;
+
+    let mapping = MappingView::from_slice(r8).unwrap();
+    let cls = mapping.find_class("com.exmaple.app.MainActivity").unwrap();
+    assert_eq!(
+        cls.members()
+            .filter(|m| m.alias() == "buttonClicked")
+            .count(),
+        3
+    );
+
+    // https://github.com/getsentry/rust-proguard/issues/6#issuecomment-605613412
+    let pg = br#"com.exmaple.app.MainActivity -> com.exmaple.app.MainActivity:
+    com.example1.domain.MyBean myBean -> k
+    11:11:void <init>() -> <init>
+    17:26:void onCreate(android.os.Bundle) -> onCreate
+    29:30:void buttonClicked(android.view.View) -> buttonClicked
+    1016:1016:void com.example1.domain.MyBean.doWork():16:16 -> buttonClicked
+    1016:1016:void buttonClicked(android.view.View):29 -> buttonClicked"#;
+
+    let mapping = MappingView::from_slice(pg).unwrap();
+    let cls = mapping.find_class("com.exmaple.app.MainActivity").unwrap();
+    assert_eq!(
+        cls.members()
+            .filter(|m| m.alias() == "buttonClicked")
+            .count(),
+        3
+    );
+}


### PR DESCRIPTION
Inlined methods only have a single trailing line number.

fixes #5
fixes #6

This is only the first step though, as proper inlining support has to happen in symbolic.