### PR TITLE
feat: Add summary information to the mapping

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ mod stacktrace;
 
 pub use mapper::{ProguardMapper, RemappedFrameIter};
 pub use mapping::{
-    LineMapping, ParseError, ParseErrorKind, ProguardMapping, ProguardRecord, ProguardRecordIter,
+    LineMapping, MappingSummary, ParseError, ParseErrorKind, ProguardMapping, ProguardRecord,
+    ProguardRecordIter,
 };
 pub use stacktrace::StackFrame;

--- a/tests/r8.rs
+++ b/tests/r8.rs
@@ -69,6 +69,18 @@ fn test_method_matches() {
     assert_eq!(mapped.next(), None);
 }
 
+#[test]
+fn test_summary() {
+    let mapping = ProguardMapping::new(MAPPING_R8);
+
+    let summary = mapping.summary();
+    assert_eq!(summary.compiler(), Some("R8"));
+    assert_eq!(summary.compiler_version(), Some("1.3.49"));
+    assert_eq!(summary.min_api(), Some(15));
+    assert_eq!(summary.class_count(), 1167);
+    assert_eq!(summary.method_count(), 24076);
+}
+
 #[cfg(feature = "uuid")]
 #[test]
 fn test_uuid() {


### PR DESCRIPTION
This gives a quick summary of the proguard mapping file for debug purposes.