### PR TITLE
fix: Remove limit in has_line_info

### DIFF
--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -206,9 +206,7 @@ impl<'s> ProguardMapping<'s> {
     /// assert_eq!(without.has_line_info(), false);
     /// ```
     pub fn has_line_info(&self) -> bool {
-        // Similarly to `is_valid` above, we only scan the first 100 lines, and
-        // are looking for a method record with a valid line_mapping.
-        for record in self.iter().take(100) {
+        for record in self.iter() {
             if let Ok(ProguardRecord::Method { line_mapping, .. }) = record {
                 if line_mapping.is_some() {
                     return true;


### PR DESCRIPTION
I tried using sentry-cli for one of the projects I'm currently working on, but it is failing with this message:
```bash
$ sentry-cli upload-proguard --app-id XXX --version XXX --no-upload app/build/outputs/mapping/remoteTestRelease/mapping.txt 
warning: proguard mapping 'app/build/outputs/mapping/remoteTestRelease/mapping.txt' was ignored because it does not contain any line information.
> compressing mappings
> skipping upload.
```

After a quick investigation I stumbled upon `has_line_info` implementation - I added some tracing code to see why it fails:
```rust
let mut line = 0;
for record in self.iter() {
    if let Ok(ProguardRecord::Method { line_mapping, .. }) = record {
        if line_mapping.is_some() {
            println!("Found mapping on line {}", line);
            return true
        }
    }
    line += 1;
}
```

which gave me 
```
$ sentry-cli upload-proguard --app-id XXX --version XXX --no-upload app/build/outputs/mapping/remoteTestRelease/mapping.txt 
Found mapping on line 3288
> compressing mappings
```

I'm not sure if increasing the line limit to 1000 or 10k would fix the parsing behavior for everyone (currently my mapping.txt is 20MB and the application is not really that big), so I decided on removing it completely.