### PR TITLE
Allow remapping just a method without line numbers

### DIFF
--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -195,9 +195,9 @@ impl<'s> ProguardMapper<'s> {
     /// The `class` argument has to be the fully-qualified obfuscated name of the
     /// class, with its complete module prefix.
     ///
-    /// The `method` will be resolved if that can be done unambiguously,
-    /// otherwise `None` is being returned.
-    pub fn remap_method(&'s self, class: &str, method: &str) -> Option<&'s str> {
+    /// If the `method` can be resolved unambiguously, it will be returned
+    /// alongside the remapped `class`, otherwise `None` is being returned.
+    pub fn remap_method(&'s self, class: &str, method: &str) -> Option<(&'s str, &'s str)> {
         let class = self.classes.get(class)?;
         let mut members = class.members.get(method)?.iter();
         let first = members.next()?;
@@ -207,7 +207,7 @@ impl<'s> ProguardMapper<'s> {
         // We could potentially skip inlined functions here, but lets rather be conservative.
         let all_matching = members.all(|member| member.original == first.original);
 
-        all_matching.then_some(first.original)
+        all_matching.then_some((class.original, first.original))
     }
 
     /// Remaps a single Stackframe.

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -47,7 +47,7 @@ impl<'m> Iterator for RemappedFrameIter<'m> {
         let (frame, ref mut members) = self.inner.as_mut()?;
 
         for member in members {
-            // skip any members which do not match our the frames line
+            // skip any members which do not match our frames line
             if member.endline > 0 && (frame.line < member.startline || frame.line > member.endline)
             {
                 continue;
@@ -190,6 +190,26 @@ impl<'s> ProguardMapper<'s> {
         self.classes.get(class).map(|class| class.original)
     }
 
+    /// Remaps an obfuscated Class Method.
+    ///
+    /// The `class` argument has to be the fully-qualified obfuscated name of the
+    /// class, with its complete module prefix.
+    ///
+    /// The `method` will be resolved if that can be done unambiguously,
+    /// otherwise `None` is being returned.
+    pub fn remap_method(&'s self, class: &str, method: &str) -> Option<&'s str> {
+        let class = self.classes.get(class)?;
+        let mut members = class.members.get(method)?.iter();
+        let first = members.next()?;
+
+        // We conservatively check that all the mappings point to the same method,
+        // as we don’t have line numbers to disambiguate.
+        // We could potentially skip inlined functions here, but lets rather be conservative.
+        let all_matching = members.all(|member| member.original == first.original);
+
+        all_matching.then_some(first.original)
+    }
+
     /// Remaps a single Stackframe.
     ///
     /// Returns zero or more [`StackFrame`]s, based on the information in
@@ -231,7 +251,7 @@ impl<'s> ProguardMapper<'s> {
         })
     }
 
-    /// Remaps a complete Java StackTrace, similar to [`Self::remap_stacktrace`] but instead works on
+    /// Remaps a complete Java StackTrace, similar to [`Self::remap_stacktrace_typed`] but instead works on
     /// strings as input and output.
     pub fn remap_stacktrace(&self, input: &str) -> Result<String, std::fmt::Error> {
         let mut stacktrace = String::new();

--- a/tests/retrace.rs
+++ b/tests/retrace.rs
@@ -106,3 +106,23 @@ fn test_remap_kotlin() {
             .trim()
     );
 }
+
+#[test]
+fn test_remap_just_method() {
+    let mapper = ProguardMapper::from(
+        r#"com.exmaple.app.MainActivity -> com.exmaple.app.MainActivity:
+    com.example1.domain.MyBean myBean -> p
+    1:1:void <init>():11:11 -> <init>
+    1:1:void buttonClicked(android.view.View):29:29 -> buttonClicked
+    2:2:void com.example1.domain.MyBean.doWork():16:16 -> buttonClicked
+    2:2:void buttonClicked(android.view.View):29 -> buttonClicked
+    1:1:void onCreate(android.os.Bundle):17:17 -> onCreate
+    2:5:void onCreate(android.os.Bundle):22:25 -> onCreate"#,
+    );
+
+    let unambiguous = mapper.remap_method("com.exmaple.app.MainActivity", "onCreate");
+    assert_eq!(unambiguous, Some("onCreate"));
+
+    let ambiguous = mapper.remap_method("com.exmaple.app.MainActivity", "buttonClicked");
+    assert_eq!(ambiguous, None);
+}

--- a/tests/retrace.rs
+++ b/tests/retrace.rs
@@ -110,7 +110,7 @@ fn test_remap_kotlin() {
 #[test]
 fn test_remap_just_method() {
     let mapper = ProguardMapper::from(
-        r#"com.exmaple.app.MainActivity -> com.exmaple.app.MainActivity:
+        r#"com.exmaple.app.MainActivity -> a.b.c.d:
     com.example1.domain.MyBean myBean -> p
     1:1:void <init>():11:11 -> <init>
     1:1:void buttonClicked(android.view.View):29:29 -> buttonClicked
@@ -120,9 +120,12 @@ fn test_remap_just_method() {
     2:5:void onCreate(android.os.Bundle):22:25 -> onCreate"#,
     );
 
-    let unambiguous = mapper.remap_method("com.exmaple.app.MainActivity", "onCreate");
-    assert_eq!(unambiguous, Some("onCreate"));
+    let unambiguous = mapper.remap_method("a.b.c.d", "onCreate");
+    assert_eq!(
+        unambiguous,
+        Some(("com.exmaple.app.MainActivity", "onCreate"))
+    );
 
-    let ambiguous = mapper.remap_method("com.exmaple.app.MainActivity", "buttonClicked");
+    let ambiguous = mapper.remap_method("a.b.c.d", "buttonClicked");
     assert_eq!(ambiguous, None);
 }


### PR DESCRIPTION
This takes a conservative approach and will ignore mappings that are ambiguous.