### PR TITLE
feat: Add support for frame deobfuscation when line is missing

### DIFF
--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -19,6 +19,7 @@ struct MemberMapping<'s> {
 #[derive(Clone, Debug)]
 struct ClassMembers<'s> {
     all_mappings: Vec<MemberMapping<'s>>,
+    // method_params -> Vec[MemberMapping]
     mappings_by_params: HashMap<&'s str, Vec<MemberMapping<'s>>>,
 }
 

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -99,22 +99,21 @@ fn iterate_without_lines<'a>(
     frame: &mut StackFrame<'a>,
     members: &mut core::slice::Iter<'_, MemberMapping<'a>>,
 ) -> Option<StackFrame<'a>> {
-    match members.next() {
-        Some(member) => {
-            let class = match member.original_class {
-                Some(class) => class,
-                _ => frame.class,
-            };
-            Some(StackFrame {
-                class,
-                method: member.original,
-                file: None,
-                line: 0,
-                parameters: frame.parameters,
-            })
-        }
-        None => None,
-    }
+    let member = members.next()?;
+
+    let class = match member.original_class {
+        Some(class) => class,
+        _ => frame.class,
+    };
+    Some(StackFrame {
+        class,
+        method: member.original,
+        file: None,
+        line: 0,
+        parameters: frame.parameters,
+    })
+
+
 }
 
 impl FusedIterator for RemappedFrameIter<'_> {}

--- a/src/stacktrace.rs
+++ b/src/stacktrace.rs
@@ -157,6 +157,7 @@ pub struct StackFrame<'s> {
     pub(crate) method: &'s str,
     pub(crate) line: usize,
     pub(crate) file: Option<&'s str>,
+    pub(crate) parameters: Option<&'s str>,
 }
 
 impl<'s> StackFrame<'s> {
@@ -167,6 +168,7 @@ impl<'s> StackFrame<'s> {
             method,
             line,
             file: None,
+            parameters: None,
         }
     }
 
@@ -177,6 +179,19 @@ impl<'s> StackFrame<'s> {
             method,
             line,
             file: Some(file),
+            parameters: None,
+        }
+    }
+
+    /// Create a new StackFrame with farguments information and no line.
+    /// This is useful for when we try to do deobfuscation with no line information.
+    pub fn with_parameters(class: &'s str, method: &'s str, arguments: &'s str) -> Self {
+        Self {
+            class,
+            method,
+            line: 0,
+            file: None,
+            parameters: Some(arguments),
         }
     }
 
@@ -262,6 +277,7 @@ pub(crate) fn parse_frame(line: &str) -> Option<StackFrame> {
         method,
         file: Some(file),
         line,
+        parameters: None,
     })
 }
 
@@ -368,6 +384,7 @@ mod tests {
                 method: "show",
                 line: 5,
                 file: Some("Util.java"),
+                parameters: None,
             }],
             cause: Some(Box::new(StackTrace {
                 exception: Some(Throwable {
@@ -379,6 +396,7 @@ mod tests {
                     method: "parse",
                     line: 115,
                     file: None,
+                    parameters: None,
                 }],
                 cause: None,
             })),
@@ -401,6 +419,7 @@ Caused by: com.example.Other: Invalid data
             method: "onClick",
             line: 1,
             file: Some("SourceFile"),
+            parameters: None,
         });
 
         assert_eq!(expect, stack_frame);
@@ -423,6 +442,7 @@ Caused by: com.example.Other: Invalid data
             method: "onClick",
             line: 1,
             file: None,
+            parameters: None,
         };
 
         assert_eq!(
@@ -435,6 +455,7 @@ Caused by: com.example.Other: Invalid data
             method: "onClick",
             line: 1,
             file: Some("SourceFile"),
+            parameters: None,
         };
 
         assert_eq!(


### PR DESCRIPTION
Take advantage of the method's parameter list, if passed, to deobfuscate the method name when line info is not available.

This support our profiling use case specifically where we don't get line info.