### PR TITLE
Clear `unique_methods` per `class`

### DIFF
--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -147,7 +147,7 @@ impl<'s> ProguardMapper<'s> {
             obfuscated: "",
             members: HashMap::new(),
         };
-        let mut unique_methods: HashSet<(&str, &str, &str, &str)> = HashSet::new();
+        let mut unique_methods: HashSet<(&str, &str, &str)> = HashSet::new();
 
         let mut records = mapping.iter().filter_map(Result::ok).peekable();
         while let Some(record) = records.next() {
@@ -163,7 +163,8 @@ impl<'s> ProguardMapper<'s> {
                         original,
                         obfuscated,
                         members: HashMap::new(),
-                    }
+                    };
+                    unique_methods.clear();
                 }
                 ProguardRecord::Method {
                     original,
@@ -224,7 +225,7 @@ impl<'s> ProguardMapper<'s> {
                         }
                     }
 
-                    let key = (class.obfuscated, obfuscated, arguments, original);
+                    let key = (obfuscated, arguments, original);
                     if unique_methods.insert(key) {
                         members
                             .mappings_by_params


### PR DESCRIPTION
We used to put *all* the `unique_methods` in a global `HashSet`, using the classname as one of the keys. This is not necessary, as we can split this by class, remove that additional key, and clear the `HashSet` for each class.