### PR TITLE
enhance: make mapping by params initialization optional

### DIFF
--- a/benches/proguard_parsing.rs
+++ b/benches/proguard_parsing.rs
@@ -4,7 +4,7 @@ use proguard::{ProguardMapper, ProguardMapping};
 static MAPPING: &[u8] = include_bytes!("../tests/res/mapping.txt");
 
 fn proguard_mapper(mapping: ProguardMapping) -> ProguardMapper {
-    ProguardMapper::new(mapping)
+    ProguardMapper::new(mapping, false)
 }
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -20,7 +20,7 @@ fn test_basic() {
     assert!(mapping.is_valid());
     assert!(mapping.has_line_info());
 
-    let mapper = ProguardMapper::new(mapping);
+    let mapper = ProguardMapper::new(mapping, false);
 
     let class = mapper.remap_class("android.support.constraint.ConstraintLayout$a");
     assert_eq!(
@@ -35,7 +35,7 @@ fn test_basic_win() {
     assert!(mapping.is_valid());
     assert!(mapping.has_line_info());
 
-    let mapper = ProguardMapper::new(mapping);
+    let mapper = ProguardMapper::new(mapping, false);
 
     let class = mapper.remap_class("android.support.constraint.ConstraintLayout$a");
     assert_eq!(
@@ -46,7 +46,7 @@ fn test_basic_win() {
 
 #[test]
 fn test_method_matches() {
-    let mapper = ProguardMapper::new(ProguardMapping::new(MAPPING));
+    let mapper = ProguardMapper::new(ProguardMapping::new(MAPPING), false);
 
     let mut mapped =
         mapper.remap_frame(&StackFrame::new("android.support.constraint.a.a", "a", 320));
@@ -77,7 +77,7 @@ fn test_method_matches() {
 
 #[test]
 fn test_method_matches_win() {
-    let mapper = ProguardMapper::new(ProguardMapping::new(&MAPPING_WIN[..]));
+    let mapper = ProguardMapper::new(ProguardMapping::new(&MAPPING_WIN[..]), false);
 
     let mut mapped =
         mapper.remap_frame(&StackFrame::new("android.support.constraint.a.a", "a", 320));
@@ -119,7 +119,7 @@ fn test_inlines() {
         );
     }
 
-    let mapper = ProguardMapper::new(mapping);
+    let mapper = ProguardMapper::new(mapping, false);
 
     let raw = r#"java.lang.RuntimeException: Button press caused an exception!
     at io.sentry.sample.MainActivity.t(MainActivity.java:1)

--- a/tests/callback.rs
+++ b/tests/callback.rs
@@ -8,7 +8,7 @@ static MAPPING_CALLBACK_INNER_CLASS: &[u8] = include_bytes!("res/mapping-callbac
 fn test_method_matches_callback() {
     // see the following files for sources used when creating the mapping file:
     //   - res/mapping-callback_EditActivity.kt
-    let mapper = ProguardMapper::new(ProguardMapping::new(MAPPING_CALLBACK));
+    let mapper = ProguardMapper::new(ProguardMapping::new(MAPPING_CALLBACK), false);
 
     let mut mapped = mapper.remap_frame(&StackFrame::new(
         "io.sentry.samples.instrumentation.ui.g",
@@ -40,7 +40,7 @@ fn test_method_matches_callback_extra_class() {
     // see the following files for sources used when creating the mapping file:
     //   - res/mapping-callback-extra-class_EditActivity.kt
     //   - res/mapping-callback-extra-class_TestSourceContext.kt
-    let mapper = ProguardMapper::new(ProguardMapping::new(MAPPING_CALLBACK_EXTRA_CLASS));
+    let mapper = ProguardMapper::new(ProguardMapping::new(MAPPING_CALLBACK_EXTRA_CLASS), false);
 
     let mut mapped = mapper.remap_frame(&StackFrame::new(
         "io.sentry.samples.instrumentation.ui.g",
@@ -87,7 +87,7 @@ fn test_method_matches_callback_extra_class() {
 fn test_method_matches_callback_inner_class() {
     // see the following files for sources used when creating the mapping file:
     //   - res/mapping-callback-inner-class_EditActivity.kt
-    let mapper = ProguardMapper::new(ProguardMapping::new(MAPPING_CALLBACK_INNER_CLASS));
+    let mapper = ProguardMapper::new(ProguardMapping::new(MAPPING_CALLBACK_INNER_CLASS), false);
 
     let mut mapped = mapper.remap_frame(&StackFrame::new(
         "io.sentry.samples.instrumentation.ui.g",

--- a/tests/r8.rs
+++ b/tests/r8.rs
@@ -21,7 +21,7 @@ fn test_basic_r8() {
     assert!(mapping.is_valid());
     assert!(mapping.has_line_info());
 
-    let mapper = ProguardMapper::new(mapping);
+    let mapper = ProguardMapper::new(mapping, false);
 
     let class = mapper.remap_class("a.a.a.a.c");
     assert_eq!(class, Some("android.arch.core.executor.ArchTaskExecutor"));
@@ -29,7 +29,7 @@ fn test_basic_r8() {
 
 #[test]
 fn test_extra_methods() {
-    let mapper = ProguardMapper::new(ProguardMapping::new(MAPPING_R8));
+    let mapper = ProguardMapper::new(ProguardMapping::new(MAPPING_R8), false);
 
     let mut mapped = mapper.remap_frame(&StackFrame::new("a.a.a.b.c$a", "<init>", 1));
 
@@ -46,7 +46,7 @@ fn test_extra_methods() {
 
 #[test]
 fn test_method_matches() {
-    let mapper = ProguardMapper::new(ProguardMapping::new(MAPPING_R8));
+    let mapper = ProguardMapper::new(ProguardMapping::new(MAPPING_R8), false);
 
     let mut mapped = mapper.remap_frame(&StackFrame::new("a.a.a.b.c", "a", 1));
 


### PR DESCRIPTION
For most of the use cases where line numbers are provided it's not necessary to keep the extra `mappings_by_params` hashmap.

This make the `mappings_by_params` initialization optional to improve both the parsing speed and the memory consumpion.