### PR TITLE
Support symbolicated file names

### DIFF
--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -87,9 +87,8 @@ fn iterate_with_lines<'a>(
         } else {
             member.original_startline + frame.line - member.startline
         };
-        let file = if member.original_file.is_some() {
-            let file_name = member.original_file.unwrap();
-            if file_name.eq("R8$$SyntheticClass") {
+        let file = if let Some(file_name) = member.original_file {
+            if file_name == "R8$$SyntheticClass" {
                 extract_class_name(member.original_class.unwrap_or(frame.class))
             } else {
                 member.original_file

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -27,6 +27,7 @@ struct ClassMembers<'s> {
 struct ClassMapping<'s> {
     original: &'s str,
     obfuscated: &'s str,
+    file_name: Option<&'s str>,
     members: HashMap<&'s str, ClassMembers<'s>>,
 }
 
@@ -169,6 +170,7 @@ impl<'s> ProguardMapper<'s> {
         let mut class = ClassMapping {
             original: "",
             obfuscated: "",
+            file_name: None,
             members: HashMap::new(),
         };
         let mut unique_methods: HashSet<(&str, &str, &str)> = HashSet::new();
@@ -176,6 +178,14 @@ impl<'s> ProguardMapper<'s> {
         let mut records = mapping.iter().filter_map(Result::ok).peekable();
         while let Some(record) = records.next() {
             match record {
+                ProguardRecord::Header {
+                    key,
+                    value
+                } => {
+                    if key == "sourceFile" {
+                        class.file_name = value;
+                    }
+                }
                 ProguardRecord::Class {
                     original,
                     obfuscated,
@@ -186,6 +196,7 @@ impl<'s> ProguardMapper<'s> {
                     class = ClassMapping {
                         original,
                         obfuscated,
+                        file_name: None,
                         members: HashMap::new(),
                     };
                     unique_methods.clear();

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -11,6 +11,7 @@ struct MemberMapping<'s> {
     startline: usize,
     endline: usize,
     original_class: Option<&'s str>,
+    original_file: Option<&'s str>,
     original: &'s str,
     original_startline: usize,
     original_endline: Option<usize>,
@@ -80,9 +81,11 @@ fn iterate_with_lines<'a>(
         } else {
             member.original_startline + frame.line - member.startline
         };
-        // when an inlined function is from a foreign class, we
-        // don’t know the file it is defined in.
-        let file = if member.original_class.is_some() {
+        let file = if member.original_file.is_some() {
+            member.original_file
+        } else if member.original_class.is_some() {
+            // when an inlined function is from a foreign class, we
+            // don’t know the file it is defined in.
             None
         } else {
             frame.file
@@ -241,6 +244,7 @@ impl<'s> ProguardMapper<'s> {
                         startline,
                         endline,
                         original_class,
+                        original_file: class.file_name,
                         original,
                         original_startline,
                         original_endline,

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -454,8 +454,7 @@ const SOURCE_FILE_PREFIX: &[u8; 32] = br#" {"id":"sourceFile","fileName":""#;
 fn parse_proguard_header(bytes: &[u8]) -> Result<(ProguardRecord, &[u8]), ParseError> {
     let bytes = parse_prefix(bytes, b"#")?;
 
-    if bytes.starts_with(SOURCE_FILE_PREFIX) {
-        let bytes = parse_prefix(bytes, SOURCE_FILE_PREFIX).unwrap();
+    if let Ok(bytes) = parse_prefix(bytes, SOURCE_FILE_PREFIX) {
         let (value, bytes) = parse_until(bytes, |c| *c == b'"')?;
         let bytes = parse_prefix(bytes, br#""}"#)?;
 

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -448,7 +448,7 @@ fn parse_proguard_record(bytes: &[u8]) -> (Result<ProguardRecord, ParseError>, &
     }
 }
 
-const SOURCE_FILE_PREFIX: &'static [u8; 32] = br#" {"id":"sourceFile","fileName":""#;
+const SOURCE_FILE_PREFIX: &[u8; 32] = br#" {"id":"sourceFile","fileName":""#;
 
 /// Parses a single Proguard Header from a Proguard File.
 fn parse_proguard_header(bytes: &[u8]) -> Result<(ProguardRecord, &[u8]), ParseError> {
@@ -456,7 +456,9 @@ fn parse_proguard_header(bytes: &[u8]) -> Result<(ProguardRecord, &[u8]), ParseE
 
     if bytes.starts_with(SOURCE_FILE_PREFIX) {
         let (value, bytes) = match parse_prefix(bytes, SOURCE_FILE_PREFIX) {
-            Ok(bytes) => parse_until(bytes, |c| *c == b'"').map(|(value, bytes)| (Some(value), bytes)),
+            Ok(bytes) => {
+                parse_until(bytes, |c| *c == b'"').map(|(value, bytes)| (Some(value), bytes))
+            }
             Err(_) => Ok((None, bytes)),
         }?;
 

--- a/tests/callback.rs
+++ b/tests/callback.rs
@@ -18,18 +18,20 @@ fn test_method_matches_callback() {
 
     assert_eq!(
         mapped.next().unwrap(),
-        StackFrame::new(
+        StackFrame::with_file(
             "io.sentry.samples.instrumentation.ui.EditActivity",
             "onCreate$lambda$1",
-            37
+            37,
+            "R8$$SyntheticClass",
         )
     );
     assert_eq!(
         mapped.next().unwrap(),
-        StackFrame::new(
+        StackFrame::with_file(
             "io.sentry.samples.instrumentation.ui.EditActivity$$InternalSyntheticLambda$1$ebaa538726b99bb77e0f5e7c86443911af17d6e5be2b8771952ae0caa4ff2ac7$0",
             "onMenuItemClick",
-            0
+            0,
+            "R8$$SyntheticClass",
         )
     );
     assert_eq!(mapped.next(), None);
@@ -50,34 +52,38 @@ fn test_method_matches_callback_extra_class() {
 
     assert_eq!(
         mapped.next().unwrap(),
-        StackFrame::new(
+        StackFrame::with_file(
             "io.sentry.samples.instrumentation.ui.TestSourceContext",
             "test2",
-            10
+            10,
+                "R8$$SyntheticClass",
         )
     );
     assert_eq!(
         mapped.next().unwrap(),
-        StackFrame::new(
+        StackFrame::with_file(
             "io.sentry.samples.instrumentation.ui.TestSourceContext",
             "test",
-            6
+            6,
+            "R8$$SyntheticClass",
         )
     );
     assert_eq!(
         mapped.next().unwrap(),
-        StackFrame::new(
+        StackFrame::with_file(
             "io.sentry.samples.instrumentation.ui.EditActivity",
             "onCreate$lambda$1",
-            38
+            38,
+            "R8$$SyntheticClass",
         )
     );
     assert_eq!(
         mapped.next().unwrap(),
-        StackFrame::new(
+        StackFrame::with_file(
             "io.sentry.samples.instrumentation.ui.EditActivity$$InternalSyntheticLambda$1$ebaa538726b99bb77e0f5e7c86443911af17d6e5be2b8771952ae0caa4ff2ac7$0",
             "onMenuItemClick",
-            0
+            0,
+            "R8$$SyntheticClass",
         )
     );
     assert_eq!(mapped.next(), None);
@@ -97,26 +103,29 @@ fn test_method_matches_callback_inner_class() {
 
     assert_eq!(
         mapped.next().unwrap(),
-        StackFrame::new(
+        StackFrame::with_file(
             "io.sentry.samples.instrumentation.ui.EditActivity$InnerEditActivityClass",
             "testInner",
-            19
+            19,
+            "R8$$SyntheticClass",
         )
     );
     assert_eq!(
         mapped.next().unwrap(),
-        StackFrame::new(
+        StackFrame::with_file(
             "io.sentry.samples.instrumentation.ui.EditActivity",
             "onCreate$lambda$1",
-            45
+            45,
+            "R8$$SyntheticClass",
         )
     );
     assert_eq!(
         mapped.next().unwrap(),
-        StackFrame::new(
+        StackFrame::with_file(
             "io.sentry.samples.instrumentation.ui.EditActivity$$InternalSyntheticLambda$1$ebaa538726b99bb77e0f5e7c86443911af17d6e5be2b8771952ae0caa4ff2ac7$0",
             "onMenuItemClick",
-            0
+            0,
+            "R8$$SyntheticClass",
         )
     );
     assert_eq!(mapped.next(), None);

--- a/tests/callback.rs
+++ b/tests/callback.rs
@@ -22,7 +22,7 @@ fn test_method_matches_callback() {
             "io.sentry.samples.instrumentation.ui.EditActivity",
             "onCreate$lambda$1",
             37,
-            "R8$$SyntheticClass",
+            "EditActivity",
         )
     );
     assert_eq!(
@@ -31,7 +31,7 @@ fn test_method_matches_callback() {
             "io.sentry.samples.instrumentation.ui.EditActivity$$InternalSyntheticLambda$1$ebaa538726b99bb77e0f5e7c86443911af17d6e5be2b8771952ae0caa4ff2ac7$0",
             "onMenuItemClick",
             0,
-            "R8$$SyntheticClass",
+            "EditActivity",
         )
     );
     assert_eq!(mapped.next(), None);
@@ -56,7 +56,7 @@ fn test_method_matches_callback_extra_class() {
             "io.sentry.samples.instrumentation.ui.TestSourceContext",
             "test2",
             10,
-                "R8$$SyntheticClass",
+            "TestSourceContext",
         )
     );
     assert_eq!(
@@ -65,7 +65,7 @@ fn test_method_matches_callback_extra_class() {
             "io.sentry.samples.instrumentation.ui.TestSourceContext",
             "test",
             6,
-            "R8$$SyntheticClass",
+            "TestSourceContext",
         )
     );
     assert_eq!(
@@ -74,7 +74,7 @@ fn test_method_matches_callback_extra_class() {
             "io.sentry.samples.instrumentation.ui.EditActivity",
             "onCreate$lambda$1",
             38,
-            "R8$$SyntheticClass",
+            "EditActivity",
         )
     );
     assert_eq!(
@@ -83,7 +83,7 @@ fn test_method_matches_callback_extra_class() {
             "io.sentry.samples.instrumentation.ui.EditActivity$$InternalSyntheticLambda$1$ebaa538726b99bb77e0f5e7c86443911af17d6e5be2b8771952ae0caa4ff2ac7$0",
             "onMenuItemClick",
             0,
-            "R8$$SyntheticClass",
+            "EditActivity",
         )
     );
     assert_eq!(mapped.next(), None);
@@ -107,7 +107,7 @@ fn test_method_matches_callback_inner_class() {
             "io.sentry.samples.instrumentation.ui.EditActivity$InnerEditActivityClass",
             "testInner",
             19,
-            "R8$$SyntheticClass",
+            "EditActivity",
         )
     );
     assert_eq!(
@@ -116,7 +116,7 @@ fn test_method_matches_callback_inner_class() {
             "io.sentry.samples.instrumentation.ui.EditActivity",
             "onCreate$lambda$1",
             45,
-            "R8$$SyntheticClass",
+            "EditActivity",
         )
     );
     assert_eq!(
@@ -125,7 +125,7 @@ fn test_method_matches_callback_inner_class() {
             "io.sentry.samples.instrumentation.ui.EditActivity$$InternalSyntheticLambda$1$ebaa538726b99bb77e0f5e7c86443911af17d6e5be2b8771952ae0caa4ff2ac7$0",
             "onMenuItemClick",
             0,
-            "R8$$SyntheticClass",
+            "EditActivity",
         )
     );
     assert_eq!(mapped.next(), None);

--- a/tests/r8.rs
+++ b/tests/r8.rs
@@ -3,6 +3,7 @@ use lazy_static::lazy_static;
 use proguard::{ProguardMapper, ProguardMapping, StackFrame};
 
 static MAPPING_R8: &[u8] = include_bytes!("res/mapping-r8.txt");
+static MAPPING_R8_SYMBOLICATED_FILE_NAMES: &[u8] = include_bytes!("res/mapping-r8-symbolicated_file_names.txt");
 
 lazy_static! {
     static ref MAPPING_WIN_R8: Vec<u8> = MAPPING_R8
@@ -97,4 +98,31 @@ fn test_uuid_win() {
         ProguardMapping::new(&MAPPING_WIN_R8[..]).uuid(),
         "d8b03b44-58df-5cd7-adc7-aefcfb0e2ade".parse().unwrap()
     );
+}
+
+#[test]
+fn test_remap_source_file() {
+    let mapping = ProguardMapping::new(MAPPING_R8_SYMBOLICATED_FILE_NAMES);
+
+    let mapper = ProguardMapper::new(mapping);
+
+    let test = mapper.remap_stacktrace(r#"
+    Caused by: java.lang.Exception: Hello from main!
+	at a.a.a(SourceFile:12)
+	at io.wzieba.r8fullmoderenamessources.MainActivity.b(SourceFile:6)
+	at io.wzieba.r8fullmoderenamessources.MainActivity.a(SourceFile:1)
+	at a.c.onClick(SourceFile:1)
+	at android.view.View.performClick(View.java:7659)
+	at android.view.View.performClickInternal(View.java:7636)
+	at android.view.View.-$$Nest$mperformClickInternal(Unknown Source:0)"#, );
+
+    assert_eq!(r#"
+    Caused by: java.lang.Exception: Hello from main!
+	at io.wzieba.r8fullmoderenamessources.Foobar.foo(Foobar.java:10)
+	at io.wzieba.r8fullmoderenamessources.MainActivity.onCreate$lambda$1$lambda$0(MainActivity.java:14)
+	at io.wzieba.r8fullmoderenamessources.MainActivity.$r8$lambda$pOQDVg57r6gG0-DzwbGf17BfNbs(MainActivity.java:0)
+	at io.wzieba.r8fullmoderenamessources.MainActivity$$ExternalSyntheticLambda0.onClick(MainActivity.java:0)
+	at android.view.View.performClick(View.java:7659)
+	at android.view.View.performClickInternal(View.java:7636)
+	at android.view.View.-$$Nest$mperformClickInternal(Unknown Source:0)"#, test.unwrap());
 }

--- a/tests/r8.rs
+++ b/tests/r8.rs
@@ -3,7 +3,8 @@ use lazy_static::lazy_static;
 use proguard::{ProguardMapper, ProguardMapping, StackFrame};
 
 static MAPPING_R8: &[u8] = include_bytes!("res/mapping-r8.txt");
-static MAPPING_R8_SYMBOLICATED_FILE_NAMES: &[u8] = include_bytes!("res/mapping-r8-symbolicated_file_names.txt");
+static MAPPING_R8_SYMBOLICATED_FILE_NAMES: &[u8] =
+    include_bytes!("res/mapping-r8-symbolicated_file_names.txt");
 
 lazy_static! {
     static ref MAPPING_WIN_R8: Vec<u8> = MAPPING_R8
@@ -106,7 +107,8 @@ fn test_remap_source_file() {
 
     let mapper = ProguardMapper::new(mapping);
 
-    let test = mapper.remap_stacktrace(r#"
+    let test = mapper.remap_stacktrace(
+        r#"
     Caused by: java.lang.Exception: Hello from main!
 	at a.a.a(SourceFile:12)
 	at io.wzieba.r8fullmoderenamessources.MainActivity.b(SourceFile:6)
@@ -114,26 +116,15 @@ fn test_remap_source_file() {
 	at a.c.onClick(SourceFile:1)
 	at android.view.View.performClick(View.java:7659)
 	at android.view.View.performClickInternal(View.java:7636)
-	at android.view.View.-$$Nest$mperformClickInternal(Unknown Source:0)"#
+	at android.view.View.-$$Nest$mperformClickInternal(Unknown Source:0)"#,
     );
 
-    /**
-    Ideally, should be (output from `retrace` tool):
-    Caused by: java.lang.Exception: Hello from main!
-   	at io.wzieba.r8fullmoderenamessources.Foobar.foo(Foobar.java:10)
-   	at io.wzieba.r8fullmoderenamessources.MainActivity.onCreate$lambda$1$lambda$0(MainActivity.java:14)
-   	at io.wzieba.r8fullmoderenamessources.MainActivity.$r8$lambda$pOQDVg57r6gG0-DzwbGf17BfNbs(MainActivity.java:0)
-   	at io.wzieba.r8fullmoderenamessources.MainActivity$$ExternalSyntheticLambda0.onClick(MainActivity.java:0)
-   	at android.view.View.performClick(View.java:7659)
-   	at android.view.View.performClickInternal(View.java:7636)
-   	at android.view.View.-$$Nest$mperformClickInternal(Unknown Source:0)
-     */
     assert_eq!(r#"
     Caused by: java.lang.Exception: Hello from main!
     at io.wzieba.r8fullmoderenamessources.Foobar.foo(Foobar.kt:10)
     at io.wzieba.r8fullmoderenamessources.MainActivity.onCreate$lambda$1$lambda$0(MainActivity.kt:14)
     at io.wzieba.r8fullmoderenamessources.MainActivity.$r8$lambda$pOQDVg57r6gG0-DzwbGf17BfNbs(MainActivity.kt:0)
-    at io.wzieba.r8fullmoderenamessources.MainActivity$$ExternalSyntheticLambda0.onClick(R8$$SyntheticClass:0)
+    at io.wzieba.r8fullmoderenamessources.MainActivity$$ExternalSyntheticLambda0.onClick(MainActivity:0)
 	at android.view.View.performClick(View.java:7659)
 	at android.view.View.performClickInternal(View.java:7636)
 	at android.view.View.-$$Nest$mperformClickInternal(Unknown Source:0)"#.trim(), test.unwrap().trim());

--- a/tests/r8.rs
+++ b/tests/r8.rs
@@ -114,16 +114,27 @@ fn test_remap_source_file() {
 	at a.c.onClick(SourceFile:1)
 	at android.view.View.performClick(View.java:7659)
 	at android.view.View.performClickInternal(View.java:7636)
-	at android.view.View.-$$Nest$mperformClickInternal(Unknown Source:0)"#.trim()
+	at android.view.View.-$$Nest$mperformClickInternal(Unknown Source:0)"#
     );
 
+    /**
+    Ideally, should be (output from `retrace` tool):
+    Caused by: java.lang.Exception: Hello from main!
+   	at io.wzieba.r8fullmoderenamessources.Foobar.foo(Foobar.java:10)
+   	at io.wzieba.r8fullmoderenamessources.MainActivity.onCreate$lambda$1$lambda$0(MainActivity.java:14)
+   	at io.wzieba.r8fullmoderenamessources.MainActivity.$r8$lambda$pOQDVg57r6gG0-DzwbGf17BfNbs(MainActivity.java:0)
+   	at io.wzieba.r8fullmoderenamessources.MainActivity$$ExternalSyntheticLambda0.onClick(MainActivity.java:0)
+   	at android.view.View.performClick(View.java:7659)
+   	at android.view.View.performClickInternal(View.java:7636)
+   	at android.view.View.-$$Nest$mperformClickInternal(Unknown Source:0)
+     */
     assert_eq!(r#"
     Caused by: java.lang.Exception: Hello from main!
-	at io.wzieba.r8fullmoderenamessources.Foobar.foo(Foobar.java:10)
-	at io.wzieba.r8fullmoderenamessources.MainActivity.onCreate$lambda$1$lambda$0(MainActivity.java:14)
-	at io.wzieba.r8fullmoderenamessources.MainActivity.$r8$lambda$pOQDVg57r6gG0-DzwbGf17BfNbs(MainActivity.java:0)
-	at io.wzieba.r8fullmoderenamessources.MainActivity$$ExternalSyntheticLambda0.onClick(MainActivity.java:0)
+    at io.wzieba.r8fullmoderenamessources.Foobar.foo(Foobar.kt:10)
+    at io.wzieba.r8fullmoderenamessources.MainActivity.onCreate$lambda$1$lambda$0(MainActivity.kt:14)
+    at io.wzieba.r8fullmoderenamessources.MainActivity.$r8$lambda$pOQDVg57r6gG0-DzwbGf17BfNbs(MainActivity.kt:0)
+    at io.wzieba.r8fullmoderenamessources.MainActivity$$ExternalSyntheticLambda0.onClick(R8$$SyntheticClass:0)
 	at android.view.View.performClick(View.java:7659)
 	at android.view.View.performClickInternal(View.java:7636)
-	at android.view.View.-$$Nest$mperformClickInternal(Unknown Source:0)"#.trim(), test.unwrap());
+	at android.view.View.-$$Nest$mperformClickInternal(Unknown Source:0)"#.trim(), test.unwrap().trim());
 }

--- a/tests/r8.rs
+++ b/tests/r8.rs
@@ -114,7 +114,8 @@ fn test_remap_source_file() {
 	at a.c.onClick(SourceFile:1)
 	at android.view.View.performClick(View.java:7659)
 	at android.view.View.performClickInternal(View.java:7636)
-	at android.view.View.-$$Nest$mperformClickInternal(Unknown Source:0)"#, );
+	at android.view.View.-$$Nest$mperformClickInternal(Unknown Source:0)"#.trim()
+    );
 
     assert_eq!(r#"
     Caused by: java.lang.Exception: Hello from main!
@@ -124,5 +125,5 @@ fn test_remap_source_file() {
 	at io.wzieba.r8fullmoderenamessources.MainActivity$$ExternalSyntheticLambda0.onClick(MainActivity.java:0)
 	at android.view.View.performClick(View.java:7659)
 	at android.view.View.performClickInternal(View.java:7636)
-	at android.view.View.-$$Nest$mperformClickInternal(Unknown Source:0)"#, test.unwrap());
+	at android.view.View.-$$Nest$mperformClickInternal(Unknown Source:0)"#.trim(), test.unwrap());
 }

--- a/tests/res/mapping-r8-symbolicated_file_names.txt
+++ b/tests/res/mapping-r8-symbolicated_file_names.txt
@@ -1,0 +1,36 @@
+# compiler: R8
+# compiler_version: 8.3.36
+# min_api: 24
+# common_typos_disable
+# {"id":"com.android.tools.r8.mapping","version":"2.2"}
+# pg_map_id: 48ffd94
+# pg_map_hash: SHA-256 48ffd9478fda293e1c713db4cc7c449781a9e799fa504e389ee32ed19775a3ba
+io.wzieba.r8fullmoderenamessources.Foobar -> a.a:
+# {"id":"sourceFile","fileName":"Foobar.kt"}
+    1:3:void <init>():3:3 -> <init>
+    4:11:void <init>():5:5 -> <init>
+    1:7:void foo():9:9 -> a
+    8:15:void foo():10:10 -> a
+io.wzieba.r8fullmoderenamessources.FoobarKt -> a.b:
+# {"id":"sourceFile","fileName":"Foobar.kt"}
+    1:5:void main():15:15 -> a
+    6:9:void main():16:16 -> a
+    1:4:void main(java.lang.String[]):0:0 -> b
+io.wzieba.r8fullmoderenamessources.MainActivity -> io.wzieba.r8fullmoderenamessources.MainActivity:
+# {"id":"sourceFile","fileName":"MainActivity.kt"}
+    1:4:void <init>():7:7 -> <init>
+    1:1:void $r8$lambda$pOQDVg57r6gG0-DzwbGf17BfNbs(android.view.View):0:0 -> a
+      # {"id":"com.android.tools.r8.synthesized"}
+    1:9:void onCreate$lambda$1$lambda$0(android.view.View):14:14 -> b
+    1:3:void onCreate(android.os.Bundle):10:10 -> onCreate
+    4:8:void onCreate(android.os.Bundle):12:12 -> onCreate
+    9:16:void onCreate(android.os.Bundle):13:13 -> onCreate
+    17:20:void onCreate(android.os.Bundle):12:12 -> onCreate
+io.wzieba.r8fullmoderenamessources.MainActivity$$ExternalSyntheticLambda0 -> a.c:
+# {"id":"sourceFile","fileName":"R8$$SyntheticClass"}
+# {"id":"com.android.tools.r8.synthesized"}
+    1:4:void onClick(android.view.View):0:0 -> onClick
+      # {"id":"com.android.tools.r8.synthesized"}
+io.wzieba.r8fullmoderenamessources.R -> a.d:
+    void <init>() -> <init>
+      # {"id":"com.android.tools.r8.synthesized"}


### PR DESCRIPTION
Closes #29 

### Early draft
hi there 👋 I'd like to present an early draft of the feature, with the hope of getting some feedback. I'm not a Rust developer and I have limited experience with R8/Proguard, so I might be missing something.

### What does it do?
It adds name of the file if R8 mapping configured one in header before the class frame. E.g. having

```
io.wzieba.r8fullmoderenamessources.Foobar -> a.a:
# {"id":"sourceFile","fileName":"Foobar.kt"}
    1:7:void foo():9:9 -> a
```

with stack trace like 
```
Caused by: java.lang.Exception: Hello from main!
	at a.a.a(SourceFile:12)
```

instead of
```
Caused by: java.lang.Exception: Hello from main!
   	at io.wzieba.r8fullmoderenamessources.Foobar.foo(SourceFile:10)
```

we should get 

```
Caused by: java.lang.Exception: Hello from main!
   	at io.wzieba.r8fullmoderenamessources.Foobar.foo(Foobar.java:10)
```
 

### Motivation
A project at our organization uses full R8 mode. For this reason, file names in stack traces are obfuscated (replaced). As `rust-proguard` tool doesn't perform deobfuscation of this type, we see the following stack traces:

![image](https://github.com/getsentry/rust-proguard/assets/5845095/9427db0c-cab7-41a0-ac98-66d4715a9671)

You can see `SourceFile` instead of the correct name of the file. This blocks features like Source Context or Stack Trace Linking.

