### PR TITLE
feat: Add cleanup_mapping_file function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ mod stacktrace;
 
 pub use mapper::{DeobfuscatedSignature, ProguardMapper, RemappedFrameIter};
 pub use mapping::{
-    LineMapping, MappingSummary, ParseError, ParseErrorKind, ProguardMapping, ProguardRecord,
-    ProguardRecordIter,
+    cleanup_mapping_file, LineMapping, MappingSummary, ParseError, ParseErrorKind, ProguardMapping,
+    ProguardRecord, ProguardRecordIter,
 };
 pub use stacktrace::{StackFrame, StackTrace, Throwable};

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -1119,10 +1119,10 @@ androidx.activity.OnBackPressedCallback
 
         cleanup_mapping_file(&mut Cursor::new(bytes), &mut out).unwrap();
 
-        let expected = r#"androidx.activity.OnBackPressedCallback -> c.a.b:
+        let expected = br#"androidx.activity.OnBackPressedCallback -> c.a.b:
 # {"id":"sourceFile","fileName":"Test.kt"}
     1:4:void onBackPressed():184:187 -> c
 "#;
-        assert_eq!(std::str::from_utf8(&out).unwrap(), expected);
+        assert_eq!(out, expected);
     }
 }


### PR DESCRIPTION
This function removes everything from a proguard file that we don't need for mapping: fields and any header that isn't `"sourceFile"`.

The purpose of this is to reduce the disk footprint of proguard files in Symbolicator.

Also includes a drive-by refactor of `has_line_info`.