### PR TITLE
feat: Add `ProguardMapping::write_class_index`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ mod stacktrace;
 
 pub use mapper::{DeobfuscatedSignature, ProguardMapper, RemappedFrameIter};
 pub use mapping::{
-    LineMapping, MappingSummary, ParseError, ParseErrorKind, ProguardMapping, ProguardRecord,
-    ProguardRecordIter,
+    ClassIndex, LineMapping, MappingSummary, ParseError, ParseErrorKind, ProguardMapping,
+    ProguardRecord, ProguardRecordIter,
 };
 pub use stacktrace::{StackFrame, StackTrace, Throwable};

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -139,7 +139,7 @@ impl<'s> MappingSummary<'s> {
 /// A class index for a proguard mapping file.
 ///
 /// This is fundamentally a map from class names to offset ranges. The value
-/// of `class` in this map is the range range of bytes between which the
+/// of `class` in this map is the range of bytes between which the
 /// mapping information for `class` is found in the mapping file
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ClassIndex<'a>(BTreeMap<Cow<'a, str>, Range<usize>>);


### PR DESCRIPTION
This is a feature that will hopefully allow us to improve proguard remapping performance down the road. Proguard files can be big (hundreds of MB) and currently we always load them into memory entirely, even if we only end up using a small part. This loading dominates proguard processing time.