### PR TITLE
cache: Add creation benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,7 +334,7 @@ dependencies = [
 
 [[package]]
 name = "proguard"
-version = "5.4.1"
+version = "5.5.0"
 dependencies = [
  "criterion",
  "lazy_static",

--- a/benches/proguard_parsing.rs
+++ b/benches/proguard_parsing.rs
@@ -21,7 +21,15 @@ fn criterion_benchmark(c: &mut Criterion) {
         b.iter(|| proguard_mapper(black_box(mapping.clone())))
     });
 
-    group.bench_function("Proguard Cache", |b| {
+    group.bench_function("Proguard Cache creation", |b| {
+        b.iter(|| {
+            let mut cache = Vec::new();
+            let mapping = ProguardMapping::new(MAPPING);
+            ProguardCache::write(&mapping, &mut cache).unwrap();
+        })
+    });
+
+    group.bench_function("Proguard Cache parsing", |b| {
         b.iter(|| proguard_cache(black_box(&cache)))
     });
 }


### PR DESCRIPTION
This adds a benchmark for creating a cache from a proguard mapping file (as distinct from parsing an already written cache file).