### PR TITLE
ref: Parse ProGuard files smarter

### DIFF
--- a/benches/proguard_parsing.rs
+++ b/benches/proguard_parsing.rs
@@ -18,7 +18,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("Proguard Parsing");
     group.bench_function("Proguard Mapper", |b| {
-        b.iter(|| proguard_mapper(black_box(mapping.clone())))
+        b.iter(|| proguard_mapper(black_box(mapping)))
     });
 
     group.bench_function("Proguard Cache creation", |b| {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,0 +1,214 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::{mapping::R8Header, ProguardMapping, ProguardRecord};
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub(crate) struct ObfuscatedName<'s>(&'s str);
+
+impl<'s> ObfuscatedName<'s> {
+    pub(crate) fn as_str(&self) -> &'s str {
+        self.0
+    }
+}
+
+impl std::ops::Deref for ObfuscatedName<'_> {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.0
+    }
+}
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub(crate) struct OriginalName<'s>(&'s str);
+
+impl<'s> OriginalName<'s> {
+    pub(crate) fn as_str(&self) -> &'s str {
+        self.0
+    }
+}
+
+impl std::ops::Deref for OriginalName<'_> {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.0
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ClassInfo<'s> {
+    pub(crate) source_file: Option<&'s str>,
+    pub(crate) members: HashMap<ObfuscatedName<'s>, Members<'s>>,
+}
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub(crate) struct MethodKey<'s> {
+    pub(crate) class: OriginalName<'s>,
+    pub(crate) name: OriginalName<'s>,
+    pub(crate) arguments: &'s str,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct MethodInfo {}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct Member<'s> {
+    pub(crate) method: MethodKey<'s>,
+    pub(crate) startline: usize,
+    pub(crate) endline: usize,
+    pub(crate) original_startline: usize,
+    pub(crate) original_endline: Option<usize>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct Members<'s> {
+    pub(crate) all: Vec<Member<'s>>,
+    pub(crate) by_params: HashMap<&'s str, Vec<Member<'s>>>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ParsedProguardMapping<'s> {
+    pub(crate) class_names: HashMap<ObfuscatedName<'s>, OriginalName<'s>>,
+    pub(crate) classes: HashMap<OriginalName<'s>, ClassInfo<'s>>,
+}
+
+impl<'s> ParsedProguardMapping<'s> {
+    pub(crate) fn parse(mapping: ProguardMapping<'s>, initialize_param_mapping: bool) -> Self {
+        let mut classes = HashMap::new();
+        let mut methods = HashMap::new();
+        let mut class_names = HashMap::new();
+        // let mut method_name_mapping: HashMap::new();
+        let mut current_class_name = None;
+        let mut current_class = ClassInfo::default();
+        let mut unique_methods: HashSet<(&str, &str, &str)> = HashSet::new();
+
+        let mut records = mapping.iter().filter_map(Result::ok).peekable();
+
+        while let Some(record) = records.next() {
+            match record {
+                ProguardRecord::Field { .. } => {}
+                ProguardRecord::Header { .. } => {}
+                ProguardRecord::R8Header(_) => {}
+                ProguardRecord::Class {
+                    original,
+                    obfuscated,
+                } => {
+                    // Flush the previous class if there is one.
+                    if let Some(name) = current_class_name {
+                        classes.insert(name, current_class);
+                    }
+                    let key = OriginalName(original);
+                    current_class_name = Some(key);
+                    current_class = ClassInfo::default();
+                    class_names.insert(ObfuscatedName(obfuscated), key);
+                    unique_methods.clear();
+
+                    // consume R8 headers attached to this class
+                    while let Some(ProguardRecord::R8Header(r8_header)) = records.peek() {
+                        match r8_header {
+                            R8Header::SourceFile { file_name } => {
+                                current_class.source_file = Some(file_name);
+                            }
+                            R8Header::Other => {}
+                        }
+
+                        records.next();
+                    }
+                }
+
+                ProguardRecord::Method {
+                    original,
+                    obfuscated,
+                    original_class,
+                    line_mapping,
+                    arguments,
+                    ..
+                } => {
+                    let current_line = if initialize_param_mapping {
+                        line_mapping
+                    } else {
+                        None
+                    };
+                    // in case the mapping has no line records, we use `0` here.
+                    let (startline, endline) =
+                        line_mapping.as_ref().map_or((0, 0), |line_mapping| {
+                            (line_mapping.startline, line_mapping.endline)
+                        });
+                    let (original_startline, original_endline) =
+                        line_mapping.map_or((0, None), |line_mapping| {
+                            match line_mapping.original_startline {
+                                Some(original_startline) => {
+                                    (original_startline, line_mapping.original_endline)
+                                }
+                                None => (line_mapping.startline, Some(line_mapping.endline)),
+                            }
+                        });
+
+                    let members = current_class
+                        .members
+                        .entry(ObfuscatedName(obfuscated))
+                        .or_default();
+
+                    let method = MethodKey {
+                        class: original_class
+                            .map(OriginalName)
+                            .or(current_class_name)
+                            .unwrap(),
+                        name: OriginalName(original),
+                        arguments,
+                    };
+
+                    let _method_info: &mut MethodInfo = methods.entry(method).or_default();
+                    let member = Member {
+                        method,
+                        startline,
+                        endline,
+                        original_startline,
+                        original_endline,
+                    };
+
+                    members.all.push(member);
+
+                    if !initialize_param_mapping {
+                        continue;
+                    }
+                    // If the next line has the same leading line range then this method
+                    // has been inlined by the code minification process, as a result
+                    // it can't show in method traces and can be safely ignored.
+                    if let Some(ProguardRecord::Method {
+                        line_mapping: Some(next_line),
+                        ..
+                    }) = records.peek()
+                    {
+                        if let Some(current_line_mapping) = current_line {
+                            if (current_line_mapping.startline == next_line.startline)
+                                && (current_line_mapping.endline == next_line.endline)
+                            {
+                                continue;
+                            }
+                        }
+                    }
+
+                    let key = (obfuscated, arguments, original);
+                    if unique_methods.insert(key) {
+                        members
+                            .by_params
+                            .entry(arguments)
+                            .or_insert_with(|| Vec::with_capacity(1))
+                            .push(member);
+                    }
+                } // end ProguardRecord::Method
+            }
+        }
+
+        if let Some(name) = current_class_name {
+            classes.insert(name, current_class);
+        }
+
+        Self {
+            classes,
+            class_names,
+        }
+    }
+}

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -467,7 +467,7 @@ fn iterate_with_lines<'a>(
             .read_string(member.original_class_offset)
             .unwrap_or(frame.class);
 
-        let file = if member.original_file_offset != u32::MAX {
+        let file = if dbg!(member.original_file_offset) != u32::MAX {
             let Ok(file_name) = cache.read_string(member.original_file_offset) else {
                 continue;
             };
@@ -477,12 +477,12 @@ fn iterate_with_lines<'a>(
             } else {
                 Some(file_name)
             }
-        } else if member.original_class_offset != u32::MAX {
+        } else if dbg!(member.original_class_offset) != u32::MAX {
             // when an inlined function is from a foreign class, we
             // don’t know the file it is defined in.
             None
         } else {
-            frame.file
+            dbg!(frame.file)
         };
 
         let Ok(method) = cache.read_string(member.original_name_offset) else {

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -467,7 +467,7 @@ fn iterate_with_lines<'a>(
             .read_string(member.original_class_offset)
             .unwrap_or(frame.class);
 
-        let file = if dbg!(member.original_file_offset) != u32::MAX {
+        let file = if member.original_file_offset != u32::MAX {
             let Ok(file_name) = cache.read_string(member.original_file_offset) else {
                 continue;
             };
@@ -477,12 +477,12 @@ fn iterate_with_lines<'a>(
             } else {
                 Some(file_name)
             }
-        } else if dbg!(member.original_class_offset) != u32::MAX {
+        } else if member.original_class_offset != u32::MAX {
             // when an inlined function is from a foreign class, we
             // don’t know the file it is defined in.
             None
         } else {
-            dbg!(frame.file)
+            frame.file
         };
 
         let Ok(method) = cache.read_string(member.original_name_offset) else {

--- a/src/cache/raw.rs
+++ b/src/cache/raw.rs
@@ -1,11 +1,10 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 use std::io::Write;
 
 use watto::{Pod, StringTable};
 
 use crate::builder::{self, ParsedProguardMapping};
-use crate::mapping::R8Header;
-use crate::{ProguardMapping, ProguardRecord};
+use crate::ProguardMapping;
 
 use super::{CacheError, CacheErrorKind};
 
@@ -331,7 +330,7 @@ impl<'data> ProguardCache<'data> {
         member: builder::Member,
     ) -> Member {
         let original_file = parsed
-            .classes
+            .class_infos
             .get(&member.method.class)
             .and_then(|class| class.source_file);
 

--- a/src/cache/raw.rs
+++ b/src/cache/raw.rs
@@ -249,25 +249,6 @@ impl<'data> ProguardCache<'data> {
             }
         }
 
-        // let obfuscated_name_offset = string_table.insert(obfuscated) as u32;
-        // let original_name_offset = string_table.insert(original) as u32;
-        // let original_class_offset = original_class.map_or(u32::MAX, |class_name| {
-        //     string_table.insert(class_name) as u32
-        // });
-        // let params_offset = string_table.insert(arguments) as u32;
-        // let original_file_offset = current_class.class.file_name_offset;
-        // let member = Member {
-        //     obfuscated_name_offset,
-        //     startline,
-        //     endline,
-        //     original_class_offset,
-        //     original_file_offset,
-        //     original_name_offset,
-        //     original_startline,
-        //     original_endline,
-        //     params_offset,
-        // };
-
         // At this point, we know how many members/members-by-params each class has because we kept count,
         // but we don't know where each class's entries start. We'll rectify that below.
 

--- a/src/cache/raw.rs
+++ b/src/cache/raw.rs
@@ -3,6 +3,7 @@ use std::io::Write;
 
 use watto::{Pod, StringTable};
 
+use crate::builder::{self, ParsedProguardMapping};
 use crate::mapping::R8Header;
 use crate::{ProguardMapping, ProguardRecord};
 
@@ -188,128 +189,87 @@ impl<'data> ProguardCache<'data> {
     /// Writes a [`ProguardMapping`] into a writer in the proguard cache format.
     pub fn write<W: Write>(mapping: &ProguardMapping, writer: &mut W) -> std::io::Result<()> {
         let mut string_table = StringTable::new();
-        let mut classes: BTreeMap<&str, ClassInProgress> = BTreeMap::new();
-        // Create an empty [`ClassInProgress`]; this gets updated as we parse method records.
-        let mut current_class = ClassInProgress::default();
 
-        let mut records = mapping.iter().filter_map(Result::ok).peekable();
-        while let Some(record) = records.next() {
-            match record {
-                ProguardRecord::R8Header(R8Header::SourceFile { file_name }) => {
-                    current_class.class.file_name_offset = string_table.insert(file_name) as u32;
-                }
-                ProguardRecord::Header { .. } => {}
-                ProguardRecord::R8Header(R8Header::Other) => {}
-                ProguardRecord::Class {
-                    original,
-                    obfuscated,
-                } => {
-                    // Finalize the previous class, but only if it has a name (otherwise it's the dummy class we created at the beginning).
-                    if !current_class.name.is_empty() {
-                        classes.insert(current_class.name, current_class);
-                    }
+        let parsed = ParsedProguardMapping::parse(*mapping, true);
 
-                    let obfuscated_name_offset = string_table.insert(obfuscated) as u32;
-                    let original_name_offset = string_table.insert(original) as u32;
-
-                    // Create a new `ClassInProgress` for the record we just encountered.
-                    current_class = ClassInProgress {
-                        name: obfuscated,
-                        class: Class {
-                            original_name_offset,
-                            obfuscated_name_offset,
-                            ..Default::default()
-                        },
-                        ..Default::default()
-                    };
-                }
-
-                ProguardRecord::Method {
-                    original,
-                    obfuscated,
-                    original_class,
-                    line_mapping,
-                    arguments,
-                    ..
-                } => {
-                    // In case the mapping has no line records, we use `0` here.
-                    let (startline, endline) = line_mapping.map_or((0, 0), |line_mapping| {
-                        (line_mapping.startline as u32, line_mapping.endline as u32)
-                    });
-                    let (original_startline, original_endline) =
-                        line_mapping.map_or((0, u32::MAX), |line_mapping| {
-                            match line_mapping.original_startline {
-                                Some(original_startline) => (
-                                    original_startline as u32,
-                                    line_mapping.original_endline.map_or(u32::MAX, |l| l as u32),
-                                ),
-                                None => {
-                                    (line_mapping.startline as u32, line_mapping.endline as u32)
-                                }
-                            }
-                        });
-
-                    let obfuscated_name_offset = string_table.insert(obfuscated) as u32;
-                    let original_name_offset = string_table.insert(original) as u32;
-                    let original_class_offset = original_class.map_or(u32::MAX, |class_name| {
-                        string_table.insert(class_name) as u32
-                    });
-                    let params_offset = string_table.insert(arguments) as u32;
-                    let original_file_offset = current_class.class.file_name_offset;
-                    let member = Member {
-                        obfuscated_name_offset,
-                        startline,
-                        endline,
-                        original_class_offset,
-                        original_file_offset,
+        // Initialize class mappings with obfuscated -> original name data. The mappings will be filled in afterwards.
+        let mut classes: BTreeMap<&str, ClassInProgress> = parsed
+            .class_names
+            .iter()
+            .map(|(obfuscated, original)| {
+                let obfuscated_name_offset = string_table.insert(obfuscated.as_str()) as u32;
+                let original_name_offset = string_table.insert(original.as_str()) as u32;
+                let class = ClassInProgress {
+                    class: Class {
                         original_name_offset,
-                        original_startline,
-                        original_endline,
-                        params_offset,
-                    };
+                        obfuscated_name_offset,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                };
 
-                    current_class
-                        .members
-                        .entry(obfuscated)
-                        .or_default()
-                        .push(member.clone());
-                    current_class.class.members_len += 1;
+                (obfuscated.as_str(), class)
+            })
+            .collect();
 
-                    // If the next line has the same leading line range then this method
-                    // has been inlined by the code minification process, as a result
-                    // it can't show in method traces and can be safely ignored.
-                    if let Some(ProguardRecord::Method {
-                        line_mapping: Some(next_line),
-                        ..
-                    }) = records.peek()
-                    {
-                        if let Some(current_line_mapping) = line_mapping {
-                            if (current_line_mapping.startline == next_line.startline)
-                                && (current_line_mapping.endline == next_line.endline)
-                            {
-                                continue;
-                            }
-                        }
-                    }
+        for ((obfuscated_class, obfuscated_method), members) in &parsed.members {
+            let current_class = classes.entry(obfuscated_class.as_str()).or_default();
 
-                    let key = (obfuscated, arguments, original);
-                    if current_class.unique_methods.insert(key) {
-                        current_class
-                            .members_by_params
-                            .entry((obfuscated, arguments))
-                            .or_default()
-                            .push(member);
-                        current_class.class.members_by_params_len += 1;
-                    }
+            let obfuscated_method_offset = string_table.insert(obfuscated_method.as_str()) as u32;
+
+            let method_mappings = current_class
+                .members
+                .entry(obfuscated_method.as_str())
+                .or_default();
+
+            for member in members.all.iter().copied() {
+                method_mappings.push(Self::resolve_mapping(
+                    &mut string_table,
+                    &parsed,
+                    obfuscated_method_offset,
+                    current_class.class.original_name_offset,
+                    member,
+                ));
+                current_class.class.members_len += 1;
+            }
+
+            for (args, param_members) in members.by_params.iter() {
+                let param_mappings = current_class
+                    .members_by_params
+                    .entry((obfuscated_method.as_str(), args))
+                    .or_default();
+
+                for member in param_members {
+                    param_mappings.push(Self::resolve_mapping(
+                        &mut string_table,
+                        &parsed,
+                        obfuscated_method_offset,
+                        current_class.class.original_name_offset,
+                        *member,
+                    ));
+                    current_class.class.members_by_params_len += 1;
                 }
-                _ => {}
             }
         }
 
-        // Flush the last constructed class
-        if !current_class.name.is_empty() {
-            classes.insert(current_class.name, current_class);
-        }
+        // let obfuscated_name_offset = string_table.insert(obfuscated) as u32;
+        // let original_name_offset = string_table.insert(original) as u32;
+        // let original_class_offset = original_class.map_or(u32::MAX, |class_name| {
+        //     string_table.insert(class_name) as u32
+        // });
+        // let params_offset = string_table.insert(arguments) as u32;
+        // let original_file_offset = current_class.class.file_name_offset;
+        // let member = Member {
+        //     obfuscated_name_offset,
+        //     startline,
+        //     endline,
+        //     original_class_offset,
+        //     original_file_offset,
+        //     original_name_offset,
+        //     original_startline,
+        //     original_endline,
+        //     params_offset,
+        // };
 
         // At this point, we know how many members/members-by-params each class has because we kept count,
         // but we don't know where each class's entries start. We'll rectify that below.
@@ -363,6 +323,46 @@ impl<'data> ProguardCache<'data> {
         Ok(())
     }
 
+    fn resolve_mapping(
+        string_table: &mut StringTable,
+        parsed: &ParsedProguardMapping<'_>,
+        obfuscated_name_offset: u32,
+        current_class_name_offset: u32,
+        member: builder::Member,
+    ) -> Member {
+        let original_file = parsed
+            .classes
+            .get(&member.method.class)
+            .and_then(|class| class.source_file);
+
+        let original_file_offset =
+            original_file.map_or(u32::MAX, |s| string_table.insert(s) as u32);
+        let original_name_offset = string_table.insert(member.method.name.as_str()) as u32;
+
+        let method_class_offset = string_table.insert(member.method.class.as_str()) as u32;
+
+        // Only fill in `original_class` if it is _not_ the current class
+        let original_class_offset = if method_class_offset != current_class_name_offset {
+            method_class_offset
+        } else {
+            u32::MAX
+        };
+
+        let params_offset = string_table.insert(member.method.arguments) as u32;
+
+        Member {
+            startline: member.startline as u32,
+            endline: member.endline as u32,
+            original_class_offset,
+            original_file_offset,
+            original_name_offset,
+            original_startline: member.original_startline as u32,
+            original_endline: member.original_endline.map_or(u32::MAX, |l| l as u32),
+            obfuscated_name_offset,
+            params_offset,
+        }
+    }
+
     /// Tests the integrity of this cache.
     ///
     /// Specifically it checks the following:
@@ -412,15 +412,10 @@ impl<'data> ProguardCache<'data> {
 /// A class that is currently being constructed in the course of writing a [`ProguardCache`].
 #[derive(Debug, Clone, Default)]
 struct ClassInProgress<'data> {
-    /// The name of the class being constructed.
-    name: &'data str,
     /// The class record.
     class: Class,
     /// The members records for the class, grouped by method name.
     members: BTreeMap<&'data str, Vec<Member>>,
     /// The member records for the class, grouped by method name and parameter string.
     members_by_params: BTreeMap<(&'data str, &'data str), Vec<Member>>,
-    /// A map to keep track of which combinations of (obfuscated method name, original method name, parameters)
-    /// we have already seen for this class.
-    unique_methods: HashSet<(&'data str, &'data str, &'data str)>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@
 
 #![warn(missing_docs)]
 
+mod builder;
 mod cache;
 mod java;
 mod mapper;

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -279,7 +279,7 @@ impl<'s> ProguardMapper<'s> {
         member: Member<'s>,
     ) -> MemberMapping<'s> {
         let original_file = parsed
-            .classes
+            .class_infos
             .get(&member.method.class)
             .and_then(|class| class.source_file);
 

--- a/src/mapping.rs
+++ b/src/mapping.rs
@@ -134,7 +134,7 @@ impl<'s> MappingSummary<'s> {
 }
 
 /// A Proguard Mapping file.
-#[derive(Clone, Default)]
+#[derive(Clone, Copy, Default)]
 pub struct ProguardMapping<'s> {
     source: &'s [u8],
 }

--- a/tests/callback.rs
+++ b/tests/callback.rs
@@ -18,20 +18,18 @@ fn test_method_matches_callback() {
 
     assert_eq!(
         mapped.next().unwrap(),
-        StackFrame::with_file(
+        StackFrame::new(
             "io.sentry.samples.instrumentation.ui.EditActivity",
             "onCreate$lambda$1",
             37,
-            "EditActivity",
         )
     );
     assert_eq!(
         mapped.next().unwrap(),
-        StackFrame::with_file(
+        StackFrame::new(
             "io.sentry.samples.instrumentation.ui.EditActivity$$InternalSyntheticLambda$1$ebaa538726b99bb77e0f5e7c86443911af17d6e5be2b8771952ae0caa4ff2ac7$0",
             "onMenuItemClick",
             0,
-            "EditActivity",
         )
     );
     assert_eq!(mapped.next(), None);
@@ -52,38 +50,34 @@ fn test_method_matches_callback_extra_class() {
 
     assert_eq!(
         mapped.next().unwrap(),
-        StackFrame::with_file(
+        StackFrame::new(
             "io.sentry.samples.instrumentation.ui.TestSourceContext",
             "test2",
             10,
-            "TestSourceContext",
         )
     );
     assert_eq!(
         mapped.next().unwrap(),
-        StackFrame::with_file(
+        StackFrame::new(
             "io.sentry.samples.instrumentation.ui.TestSourceContext",
             "test",
             6,
-            "TestSourceContext",
         )
     );
     assert_eq!(
         mapped.next().unwrap(),
-        StackFrame::with_file(
+        StackFrame::new(
             "io.sentry.samples.instrumentation.ui.EditActivity",
             "onCreate$lambda$1",
             38,
-            "EditActivity",
         )
     );
     assert_eq!(
         mapped.next().unwrap(),
-        StackFrame::with_file(
+        StackFrame::new(
             "io.sentry.samples.instrumentation.ui.EditActivity$$InternalSyntheticLambda$1$ebaa538726b99bb77e0f5e7c86443911af17d6e5be2b8771952ae0caa4ff2ac7$0",
             "onMenuItemClick",
             0,
-            "EditActivity",
         )
     );
     assert_eq!(mapped.next(), None);
@@ -107,25 +101,23 @@ fn test_method_matches_callback_inner_class() {
             "io.sentry.samples.instrumentation.ui.EditActivity$InnerEditActivityClass",
             "testInner",
             19,
-            "EditActivity",
+            "EditActivity.kt",
         )
     );
     assert_eq!(
         mapped.next().unwrap(),
-        StackFrame::with_file(
+        StackFrame::new(
             "io.sentry.samples.instrumentation.ui.EditActivity",
             "onCreate$lambda$1",
             45,
-            "EditActivity",
         )
     );
     assert_eq!(
         mapped.next().unwrap(),
-        StackFrame::with_file(
+        StackFrame::new(
             "io.sentry.samples.instrumentation.ui.EditActivity$$InternalSyntheticLambda$1$ebaa538726b99bb77e0f5e7c86443911af17d6e5be2b8771952ae0caa4ff2ac7$0",
             "onMenuItemClick",
             0,
-            "EditActivity",
         )
     );
     assert_eq!(mapped.next(), None);


### PR DESCRIPTION
Previously, `ProguardCache` and `ProguardMapper` both implemented their (structurally very similar) parsing functions. These parsing functions left a lot to be desired; the simply took records in the order they were encountered and were unable to use later information to refine previously encountered information.

This PR splits the parsing logic out into a new module `builder` (please feel free to bikeshed about this), which contains a bunch of auxiliary types and the main `ParsedProguardMapping` type. `ParsedProguardMapping` can then in turn be processed into a `ProguardMapper` or `ProguardCache`, as required.

Fixes #54. Fixes RUSTPRO-4.

As a follow-up I would like to use the newly introduced `ObfuscatedName` and `OriginalName` types throughout the crate.