### PR TITLE
chore(cargo): Update stale lock file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "proguard"
-version = "5.9.0"
+version = "5.10.3"
 dependencies = [
  "criterion",
  "serde",

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -10,3 +10,7 @@ NEW_VERSION="${2}"
 echo "Bumping version: ${NEW_VERSION}"
 
 find . -name Cargo.toml -type f -exec sed -i '' -e "s/^version.*/version = \"$NEW_VERSION\"/" {} \;
+
+# Keep Cargo.lock in sync. `--workspace` only touches our own packages, so this
+# does not pull in unrelated dependency updates.
+cargo update --workspace --offline

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -11,6 +11,4 @@ echo "Bumping version: ${NEW_VERSION}"
 
 find . -name Cargo.toml -type f -exec sed -i '' -e "s/^version.*/version = \"$NEW_VERSION\"/" {} \;
 
-# Keep Cargo.lock in sync. `--workspace` only touches our own packages, so this
-# does not pull in unrelated dependency updates.
-cargo update --workspace --offline
+cargo metadata --format-version 1 > /dev/null # update `Cargo.lock`


### PR DESCRIPTION
Running cargo build locally revealed a diff within `Cargo.lock`, as cargo build seems to silently patch the package version, ensuring it matches Cargo.toml.

This PR:

* Manually updates `Cargo.lock` package version to `"5.10.3"`, so it matches `Cargo.toml`.
* Updates the bump version script to run `cargo metadata`, so it does the lock file package version bump automatically in future. This mirrors what [vroomrs](https://github.com/getsentry/vroomrs/blob/56ae8efe7e90ec9528c8698c50a67bebad77c74a/scripts/bump-version.sh#L17) does, and works when run by craft (`cargo update --offline` would have failed on a cold cargo cache).
